### PR TITLE
Add scrollbar for long algorithm explanations

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -219,6 +219,7 @@ section {
     padding: 0 8px;
     line-height: 30px;
     font-size: 12px;
+    overflow-y: auto;
 }
 
 .data_container {


### PR DESCRIPTION
Fixes problem of:

![bug](https://cloud.githubusercontent.com/assets/10343956/15489500/324c5764-2158-11e6-9e78-16a9b4e18586.png)

By using a horizontal scrollbar when the explanation becomes too long.

If you can think of a more elegant solution (within the possibilities of CSS), let me know.