### PR TITLE
updated clear () to clear the tracer screen

### DIFF
--- a/js/module/tracer.js
+++ b/js/module/tracer.js
@@ -19,6 +19,7 @@ Tracer.prototype = {
     resize: function () {
     },
     clear: function () {
+        $('#tab_trace .wrapper').text ('');
     },
     reset: function () {
         this.traces = [];


### PR DESCRIPTION
I've inserted 1 line in the clear () function in tracer.js in order to perform the clearing of screen upon calling tracer._clear ()
If this wasn't the intended behavior, then please ignore this request