### PR TITLE
Bug fix in Array2dTracer _notify ()

### DIFF
--- a/js/module/array2d.js
+++ b/js/module/array2d.js
@@ -130,7 +130,7 @@ Array2DTracer.prototype = $.extend(true, Object.create(Tracer.prototype), {
     processStep: function (step, options) {
         switch (step.type) {
             case 'notify':
-                if (step.v) {
+                if (step.v === 0 || step.v) {
                     var $row = this.$table.find('.mtbl-row').eq(step.x);
                     var $col = $row.find('.mtbl-col').eq(step.y);
                     $col.text(TracerUtil.refineByType(step.v));


### PR DESCRIPTION
First, check out [this](http://jasonpark.me/AlgorithmVisualizer/?scratch-paper=5e605d60d2038d63439d89bec55fa18e) scratch

When I use _notify () function on 2D Array Tracer with 3rd argument (v) as 0, the value in tracer is **not updated** even though 0 is a perfectly valid value.

This is because **line 133 of  [array2d.js](https://github.com/parkjs814/AlgorithmVisualizer/blob/gh-pages/js/module/array2d.js)** says:
```
if (step.v) {...}
```

This disqualifies 0, and doesn't allow us to set it as any item's value. We need to dis-allow all false-equivalent values **apart from 0**.
I think we should even allow null, but I haven't fixed for that, only for 0.

The result is as expected on my [ghpages](http://duaraghav8.github.io/AlgorithmVisualizer/?scratch-paper=96cb9e9c8be86804a6990932865a35af)