### PR TITLE
hid spinners for number input in firefox

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -524,6 +524,10 @@ pre {
     }
 }
 
+input[type="number"] {
+    -moz-appearance: textfield;
+}
+
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button {
     -webkit-appearance: none;


### PR DESCRIPTION
Removed the spinners in Firefox in the number input for "interval". The spinners were covering part of the number before, so it always looked like 0 (rather than 0.1 or something else).