### PR TITLE
Correct another misspelling of Eratosthenes

### DIFF
--- a/algorithm/number_theory/sieve_of_erathrones/desc.json
+++ b/algorithm/number_theory/sieve_of_erathrones/desc.json
@@ -1,5 +1,5 @@
 {
-  "Sieve of Erathrones": "Finding all prime numbers upto a given range.",
+  "Sieve of Eratosthenes": "Finding all prime numbers up to a given range.",
   "Complexity": {
     "time": "O(n(log n)(log log n))",
     "space": "O(n<sup>1/2</sup>)"


### PR DESCRIPTION
I double-checked the website after you accepted my last pull request, and the Sieve menu item didn’t display anything when I clicked on it. I think this is the problem—I missed another one! I hope the last one. Sorry for breaking things. Obviously, correcting language is no small or innocent task when namespaces are involved.