### PR TITLE
Allowing for custom node positions on graphs

### DIFF
--- a/js/module/tracer/directed_graph.js
+++ b/js/module/tracer/directed_graph.js
@@ -14,6 +14,8 @@ class DirectedGraphTracer extends Tracer {
   constructor(name) {
     super(name);
 
+    this.nodePositions = [];
+
     if (this.isNew) initView(this);
   }
 
@@ -41,6 +43,13 @@ class DirectedGraphTracer extends Tracer {
       source: source
     });
     return this;
+  }
+
+  _setNodePositions(obj){
+    for(var i = 0; i < obj.length; i++){
+        this.nodePositions.push(obj[i]);
+    }
+    super.dirtyData();
   }
 
   processStep(step, options) {
@@ -116,7 +125,6 @@ class DirectedGraphTracer extends Tracer {
 
   setData(G, undirected) {
     if (super.setData.apply(this, arguments)) return true;
-
     this.graph.clear();
     const nodes = [];
     const edges = [];
@@ -127,8 +135,8 @@ class DirectedGraphTracer extends Tracer {
       nodes.push({
         id: this.n(i),
         label: '' + i,
-        x: .5 + Math.sin(currentAngle) / 2,
-        y: .5 + Math.cos(currentAngle) / 2,
+        x: (this.nodePositions[i]) ? this.nodePositions[i].x : .5 + Math.sin(currentAngle) / 2,
+        y: (this.nodePositions[i]) ? this.nodePositions[i].y : .5 + Math.cos(currentAngle) / 2,
         size: 1,
         color: this.color.default,
         weight: 0

--- a/js/module/tracer/tracer.js
+++ b/js/module/tracer/tracer.js
@@ -77,12 +77,21 @@ class Tracer {
     $name.text(name || this.defaultName);
   }
 
+  dirtyData(){
+      this.isNew = true;
+  }
+
+  cleanData(){
+      this.isNew = false;
+  }
+
   setData() {
     const data = toJSON(arguments);
     if (!this.isNew && this.lastData === data) {
       return true;
     }
     this.lastData = this.capsule.lastData = data;
+    this.cleanData();
     return false;
   }
 


### PR DESCRIPTION
Can add custom (x,y) positions for all the nodes in a graph!  This code
**should not** work or effect the graphs that are “trees”, i.e using _setTreeData.

I needed some way to force tracer._setData(G) to reset the graph even though the data in G didn't change so I added some helper functions that make the data "dirty" to force it to reset and set the data again and the node positions because they need to be redrawn on the screen. Maybe there is a better way to achieve this? 

this.nodePositions (inside directed_graph.js) stores objects in the format
`var myNodePositions = [{x:0,y:0},{x:1,y:1},{x:2,y:2}];`
`someTracer._setNodePositions(myNodePositions);`
that means the 0th node will get its (x,y) = (0,0) when drawn on the screen. This allows someone to control the positions of the nodes. 

If someone gives an array of length 4 and there are 6 nodes in the graph it will go back to the default positioning given. Thats what the ternary check is for. 
