### PR TITLE
Adding mathjax

### DIFF
--- a/algorithm/backtracking/knight's_tour/desc.json
+++ b/algorithm/backtracking/knight's_tour/desc.json
@@ -1,8 +1,8 @@
 {
   "Knight’s tour problem": "A knight's tour is a sequence of moves of a knight on a chessboard such that the knight visits every square only once. If the knight ends on a square that is one knight's move from the beginning square (so that it could tour the board again immediately, following the same path), the tour is closed, otherwise it is open.",
   "Complexity": {
-    "time": "Worst O(8<sup>N<sup>2</sup></sup>)",
-    "space": "Worst O(N<sup>2</sup>)"
+    "time": "Worst $$O(8^{N^{2}})$$",
+    "space": "Worst $$O(N^2)$$"
   },
   "References": [
     "<a href='https://en.wikipedia.org/wiki/Knight%27s_tour'>Wikipedia</a>"

--- a/algorithm/backtracking/n_queens/desc.json
+++ b/algorithm/backtracking/n_queens/desc.json
@@ -5,8 +5,8 @@
     "Searching"
   ],
   "Complexity": {
-    "time": "Worst O(N!)",
-    "space": "Worst O(N)"
+    "time": "Worst $$O(N!)$$",
+    "space": "Worst $$O(N)$$"
   },
   "References": [
     "<a href='http://www.geeksforgeeks.org/backtracking-set-3-n-queen-problem/'>geeksforgeeks</a>"

--- a/algorithm/number_theory/sieve_of_eratosthenes/desc.json
+++ b/algorithm/number_theory/sieve_of_eratosthenes/desc.json
@@ -1,8 +1,8 @@
 {
   "Sieve of Eratosthenes": "Finding all prime numbers up to a given range.",
   "Complexity": {
-    "time": "O(n(log n)(log log n))",
-    "space": "O(n<sup>1/2</sup>)"
+    "time": "$$O(n\\,(log\\,n)(log\\,log\\,n))$$",
+    "space": "$$O(n^{\\frac{1}{2}})$$"
   },
   "References": [
     "<a href='https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes'>Wikipedia</a>"

--- a/index.html
+++ b/index.html
@@ -122,6 +122,9 @@
             <a href="https://github.com/simonwhitaker/github-fork-ribbon-css">
                 <button class="indent">simonwhitaker/github-fork-ribbon-css</button>
             </a>
+            <a href="https://github.com/mathjax/MathJax">
+                <button class="indent">mathjax/MathJax</button>
+            </a>
         </div>
     </div>
     <a class="github-fork-ribbon left-bottom" href="http://github.com/parkjs814/AlgorithmVisualizer"

--- a/index.html
+++ b/index.html
@@ -11,6 +11,20 @@
     <title>Algorithm Visualizer</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
     <link rel="stylesheet" href="public/algorithm_visualizer.min.css">
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+            tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]},
+            styles: {
+                ".MJXc-display": {
+                    "display": "inline !important",
+                    "margin": "0 !important"
+                },
+            }
+        });
+    </script>
+    <script type="text/javascript" async
+      src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+    </script>
 </head>
 
 <body>
@@ -36,7 +50,6 @@
                 <span class="btn-text">Generate</span>
             </div>
         </div>
-
         <div class="btn" id="btn_share">
             <div class="wrapper">
                 <i class="fa fa-share" aria-hidden="true"></i> Share <input type="text" class="collapse" id="shared">

--- a/js/dom/show_algorithm.js
+++ b/js/dom/show_algorithm.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const app = require('../app');
-
-const {
-  isScratchPaper
-} = require('../utils');
-
+const utils = require('../utils');
 const showDescription = require('./show_description');
 const addFiles = require('./add_files');
 
@@ -14,7 +10,7 @@ module.exports = (category, algorithm, data, requestedFile) => {
   let category_name;
   let algorithm_name;
 
-  if (isScratchPaper(category)) {
+  if (utils.isScratchPaper(category)) {
     $menu = $('#scratch-paper');
     category_name = 'Scratch Paper';
     algorithm_name = algorithm ? 'Shared' : 'Temporary';
@@ -45,4 +41,5 @@ module.exports = (category, algorithm, data, requestedFile) => {
 
   showDescription(data);
   addFiles(category, algorithm, files, requestedFile);
+  utils.renderMathJax();
 };

--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -14,8 +14,13 @@ const getFileDir = (category, algorithm, file) => {
   return `./algorithm/${category}/${algorithm}/${file}/`;
 };
 
+const renderMathJax = () =>{
+    MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
+};
+
 module.exports = {
   isScratchPaper,
   getAlgorithmDir,
-  getFileDir
+  getFileDir,
+  renderMathJax
 };


### PR DESCRIPTION
Here is a quick sample of MathJax working. I am using their servers for the rendering of MathJax because the library is rather large. Whenever an algorithm is clicked it loads all the data and the last call is to render the MathJax. Also if this goes through I can help change each algorithm to use latex for the time/space complexity. I only changed a few to see if we want to use MathJax. 

Notes:
You will need to add an extra \ for every \ when writing the latex in a javascript string. I currently do not know a work around for this. 
Latex: `$$O(n\,(log\,n)(log\,log\,n))$$`
Javascript Version: `$$O(n\\,(log\\,n)(log\\,log\\,n))$$`

You can also write latex inside the algorithm description, i.g.
```javascript
{
  "Knight’s tour problem": "A knight's  $$LATEX CAN GO HERE! \\Theta$$ tour is a sequence of moves of a knight on a chessboard such that the knight visits every square only once. If the knight ends on a square that is one knight's move from the beginning square (so that it could tour the board again immediately, following the same path), the tour is closed, otherwise it is open.",
  "Complexity": {
    "time": "Worst $$O(8^{N^{2}})$$",
    "space": "Worst $$O(N^2)$$"
  },
  //etc...
}
```